### PR TITLE
fix uninstall

### DIFF
--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -1,5 +1,4 @@
 ---
----
 
 - name: Check existence of firezone systemd service
   ansible.builtin.stat:


### PR DESCRIPTION
fixed the

```
TASK [galaxy/firezone : ansible.builtin.include_tasks] ********************************************************************************************
ERROR! We were unable to read either as JSON nor YAML, these are the errors we got from each:
JSON: Expecting value: line 1 column 1 (char 0)

Syntax Error while loading YAML.
  but found another document

The error appears to be in 'mash/roles/galaxy/firezone/tasks/uninstall.yml': line 2, column 1, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

---
---
^ here

```